### PR TITLE
chore: update deps, rustc, tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ description = "Thread safe progress logging"
 pretty_counts = ["thousands"]
 
 [dependencies]
-log = "0.4.17"
+log = "0.4.27"
 thousands = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
-env_logger = "0.9.0"
-rayon = "1.5.3"
+env_logger = "0.11.8"
+rayon = "1.10.0"
 logtest = "2.0.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.62.1"
+channel = "1.85.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
- Update Rust version to 1.85.
- Update all deps to latest.
- Fix failing test on main.

The failing test is due to the relaxed atomic ordering. I don't want to use a stricter ordering and some out-of-ordering is okay. The test was fixed by fixing the number of threads to 2 and allow- int messages to be out of order by +- 10.